### PR TITLE
Feature/validate bucket name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -296,6 +297,8 @@ func LoadConfig(configFile string) (*Config, error) {
 		return nil, fmt.Errorf("no database specified in config")
 	}
 
+	var validBucketName = regexp.MustCompile(`^[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]$`)
+
 	// Validate S3 Credentials
 	for i, cred := range cfg.S3Credentials {
 		provider := strings.ToLower(strings.TrimSpace(cred.Provider))
@@ -305,6 +308,12 @@ func LoadConfig(configFile string) (*Config, error) {
 		cfg.S3Credentials[i].Provider = provider
 		if cred.Bucket == "" {
 			return nil, fmt.Errorf("s3_credentials[%d]: bucket is required", i)
+		}
+		if len(cred.Bucket) < 3 || len(cred.Bucket) > 63 {
+			return nil, fmt.Errorf("s3_credentials[%d]: bucket name %q must be 3–63 characters", i, cred.Bucket)
+		}
+		if !validBucketName.MatchString(cred.Bucket) {
+			return nil, fmt.Errorf("s3_credentials[%d]: bucket name %q is invalid (lowercase letters, numbers, hyphens only; must start and end with letter or number)", i, cred.Bucket)
 		}
 		switch provider {
 		case "s3":

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -168,3 +169,47 @@ func TestLoadConfig_LFSEnvOverrides(t *testing.T) {
 		t.Fatalf("expected 999, got %d", cfg.LFS.BandwidthLimitBytesPerMinute)
 	}
 }
+
+func TestLoadConfig_ValidBucketNames(t *testing.T) {
+	validNames := []string{
+		"abc",
+		"my-bucket",
+		"a1-b2-c3",
+		"bucket123",
+		"test-bucket-2026",
+	}
+
+	for _, bucket := range validNames {
+		t.Run(bucket, func(t *testing.T) {
+			content := fmt.Sprintf(`
+auth:
+  mode: local
+database:
+  sqlite:
+    file: "test.db"
+s3_credentials:
+  - bucket: %q
+    provider: s3
+    region: "us-east-1"
+    access_key: "test-key"
+    secret_key: "test-secret"
+`, bucket)
+
+			tmpfile, err := os.CreateTemp("", "config-valid-bucket-*.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.Write([]byte(content)); err != nil {
+				t.Fatal(err)
+			}
+			tmpfile.Close()
+
+			if _, err := LoadConfig(tmpfile.Name()); err != nil {
+				t.Fatalf("expected valid bucket %q to pass validation, got error: %v", bucket, err)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary

This PR adds stricter validation for `s3_credentials[].bucket` in config loading and introduces test coverage for valid bucket names.

## Why

Bucket names were previously validated only for presence (non-empty).  
That allowed malformed values to pass config parsing and fail later at runtime (URL signing/storage operations), producing harder-to-debug errors.

By validating bucket names during `LoadConfig`, we fail fast with explicit, actionable error messages.

## Changes

### `config/config.go`
- Added bucket-name validation in `LoadConfig` for each `s3_credentials` entry.
- Validation now enforces:
  - bucket is required
  - length is 3 to 63 characters
  - characters are lowercase letters, numbers, and `-`
  - starts and ends with lowercase letter or number

### `config/config_test.go`
- Added `TestLoadConfig_ValidBucketNames`.
- Test is table-driven and verifies representative valid names are accepted:
  - `abc`
  - `my-bucket`
  - `a1-b2-c3`
  - `bucket123`
  - `test-bucket-2026`

## Testing

Ran:

```bash
go test ./config -run ValidBucketNames -count=1
