### PR TITLE
adds badges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,25 +53,61 @@ jobs:
           mkdir -p coverage
           go test -count=1 -covermode=atomic -coverprofile=coverage/coverage.out ./...
 
-      - name: Upload root coverage to Codecov
+      - name: Upload root coverage to Codecov (OIDC)
+        id: codecov_root_oidc
+        continue-on-error: true
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_SLUG: calypr/syfon
         with:
           use_oidc: true
           files: coverage/coverage.out
           flags: root
           disable_search: true
-          slug: calypr/syfon
+          verbose: true
           fail_ci_if_error: true
 
-      - name: Upload client coverage to Codecov
+      - name: Upload root coverage to Codecov (token fallback)
+        if: steps.codecov_root_oidc.outcome == 'failure'
+        continue-on-error: true
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_SLUG: calypr/syfon
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/coverage.out
+          flags: root
+          disable_search: true
+          verbose: true
+          fail_ci_if_error: false
+
+      - name: Upload client coverage to Codecov (OIDC)
+        id: codecov_client_oidc
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_SLUG: calypr/syfon
         with:
           use_oidc: true
           files: client/coverage/coverage.out
           flags: client
           disable_search: true
-          slug: calypr/syfon
+          verbose: true
           fail_ci_if_error: true
+
+      - name: Upload client coverage to Codecov (token fallback)
+        if: steps.codecov_client_oidc.outcome == 'failure'
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_SLUG: calypr/syfon
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: client/coverage/coverage.out
+          flags: client
+          disable_search: true
+          verbose: true
+          fail_ci_if_error: false
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
           use_oidc: true
           files: coverage/coverage.out
           flags: root
+          disable_search: true
           fail_ci_if_error: true
 
       - name: Upload client coverage to Codecov
@@ -67,6 +68,7 @@ jobs:
           use_oidc: true
           files: client/coverage/coverage.out
           flags: client
+          disable_search: true
           fail_ci_if_error: true
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
         env:
           SYFON_E2E_DOCKER: 1
         run: |
-          go test -v -run TestSyfonDocker ./cmd/...
+          go test ./cmd -run TestSyfonDocker -v
   build-and-push:
     name: Build syfon
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Syfon CI
 
+permissions:
+  contents: read
+  id-token: write
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -42,6 +46,20 @@ jobs:
       - name: Run coverage
         run: make coverage
 
+      - name: Run client coverage
+        working-directory: client
+        run: |
+          mkdir -p coverage
+          go test -count=1 -covermode=atomic -coverprofile=coverage/coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage/coverage.out,client/coverage/coverage.out
+          flags: root,client
+          fail_ci_if_error: true
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -50,6 +68,7 @@ jobs:
             coverage/coverage.out
             coverage/coverage.txt
             coverage/coverage.html
+            client/coverage/coverage.out
 
       - name: Run go vet
         run: go vet ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: Syfon CI
 
 permissions:
+  actions: write
   contents: read
   id-token: write
 
@@ -52,14 +53,21 @@ jobs:
           mkdir -p coverage
           go test -count=1 -covermode=atomic -coverprofile=coverage/coverage.out ./...
 
-      - name: Upload coverage to Codecov
+      - name: Upload root coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
-          files: coverage/coverage.out,client/coverage/coverage.out
-          flags: root,client
+          files: coverage/coverage.out
+          flags: root
           fail_ci_if_error: true
 
+      - name: Upload client coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: client/coverage/coverage.out
+          flags: client
+          fail_ci_if_error: true
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
           files: coverage/coverage.out
           flags: root
           disable_search: true
+          slug: calypr/syfon
           fail_ci_if_error: true
 
       - name: Upload client coverage to Codecov
@@ -69,6 +70,7 @@ jobs:
           files: client/coverage/coverage.out
           flags: client
           disable_search: true
+          slug: calypr/syfon
           fail_ci_if_error: true
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Calypr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Go Version](https://img.shields.io/badge/go-1.26.1-00ADD8?logo=go)](https://go.dev/doc/devel/release)
 [![CI](https://github.com/calypr/syfon/actions/workflows/ci.yaml/badge.svg)](https://github.com/calypr/syfon/actions/workflows/ci.yaml)
 [![Coverage](https://codecov.io/gh/calypr/syfon/branch/main/graph/badge.svg)](https://codecov.io/gh/calypr/syfon)
-[![Security](https://snyk.io/test/github/calypr/syfon/badge.svg)](https://snyk.io/test/github/calypr/syfon)
+[![dependabot](https://img.shields.io/badge/dependabot-enabled-025E8C?logo=dependabot)](https://github.com/calypr/syfon/security/dependabot)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/calypr/syfon)](https://github.com/calypr/syfon/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 # syfon
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/calypr/syfon.svg)](https://pkg.go.dev/github.com/calypr/syfon)
+[![Go Report Card](https://goreportcard.com/badge/github.com/calypr/syfon)](https://goreportcard.com/report/github.com/calypr/syfon)
+[![Go Version](https://img.shields.io/badge/go-1.26.1-00ADD8?logo=go)](https://go.dev/doc/devel/release)
+[![CI](https://github.com/calypr/syfon/actions/workflows/ci.yaml/badge.svg)](https://github.com/calypr/syfon/actions/workflows/ci.yaml)
+[![Coverage](https://codecov.io/gh/calypr/syfon/branch/main/graph/badge.svg)](https://codecov.io/gh/calypr/syfon)
+[![Security](https://snyk.io/test/github/calypr/syfon/badge.svg)](https://snyk.io/test/github/calypr/syfon)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/calypr/syfon)](https://github.com/calypr/syfon/releases)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![GitHub Stars](https://img.shields.io/github/stars/calypr/syfon?style=social)](https://github.com/calypr/syfon/stargazers)
+
 A lightweight, production-grade implementation of a GA4GH Data Repository Service (DRS) server in Go.
 
 ## Quickstart
@@ -268,3 +279,8 @@ The project uses a Makefile for common tasks:
 The `apigen` module is currently used as a shared model/types package, not a full server/client operation generator. In practice, we generate and commit schemas/models from OpenAPI (`components/schemas`), while route handlers and request wiring are implemented manually under `internal/api/internaldrs` and related packages. This means path/operation updates in `apigen/api/*.openapi.yaml` may change contract/docs without producing new generated handler code.
 
 This is intentional for now to keep control of runtime behavior and compatibility logic. We can expand `apigen` later to include operation-level generation (`apis`/server interfaces) once we decide to move more routing and handler contracts to generated code.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE).
+

--- a/client/README.md
+++ b/client/README.md
@@ -1,7 +1,7 @@
 # syfon client (Go SDK)
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/calypr/syfon.svg)](https://pkg.go.dev/github.com/calypr/syfon)
-[![Go Report Card](https://goreportcard.com/badge/github.com/calypr/syfon)](https://goreportcard.com/report/github.com/calypr/syfon)
+[![Go Reference](https://pkg.go.dev/badge/github.com/calypr/syfon/client.svg)](https://pkg.go.dev/github.com/calypr/syfon/client)
+[![Go Report Card](https://goreportcard.com/badge/github.com/calypr/syfon/client)](https://goreportcard.com/report/github.com/calypr/syfon/client)
 [![Go Version](https://img.shields.io/badge/go-1.26.1-00ADD8?logo=go)](https://go.dev/doc/devel/release)
 [![CI](https://github.com/calypr/syfon/actions/workflows/ci.yaml/badge.svg)](https://github.com/calypr/syfon/actions/workflows/ci.yaml)
 [![Coverage](https://codecov.io/gh/calypr/syfon/branch/main/graph/badge.svg)](https://codecov.io/gh/calypr/syfon)

--- a/client/README.md
+++ b/client/README.md
@@ -5,7 +5,7 @@
 [![Go Version](https://img.shields.io/badge/go-1.26.1-00ADD8?logo=go)](https://go.dev/doc/devel/release)
 [![CI](https://github.com/calypr/syfon/actions/workflows/ci.yaml/badge.svg)](https://github.com/calypr/syfon/actions/workflows/ci.yaml)
 [![Coverage](https://codecov.io/gh/calypr/syfon/branch/main/graph/badge.svg)](https://codecov.io/gh/calypr/syfon)
-[![Security](https://snyk.io/test/github/calypr/syfon/badge.svg)](https://snyk.io/test/github/calypr/syfon)
+[![dependabot](https://img.shields.io/badge/dependabot-enabled-025E8C?logo=dependabot)](https://github.com/calypr/syfon/security/dependabot)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/calypr/syfon)](https://github.com/calypr/syfon/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../CONTRIBUTING.md)

--- a/client/README.md
+++ b/client/README.md
@@ -1,5 +1,16 @@
 # syfon client (Go SDK)
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/calypr/syfon.svg)](https://pkg.go.dev/github.com/calypr/syfon)
+[![Go Report Card](https://goreportcard.com/badge/github.com/calypr/syfon)](https://goreportcard.com/report/github.com/calypr/syfon)
+[![Go Version](https://img.shields.io/badge/go-1.26.1-00ADD8?logo=go)](https://go.dev/doc/devel/release)
+[![CI](https://github.com/calypr/syfon/actions/workflows/ci.yaml/badge.svg)](https://github.com/calypr/syfon/actions/workflows/ci.yaml)
+[![Coverage](https://codecov.io/gh/calypr/syfon/branch/main/graph/badge.svg)](https://codecov.io/gh/calypr/syfon)
+[![Security](https://snyk.io/test/github/calypr/syfon/badge.svg)](https://snyk.io/test/github/calypr/syfon)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/calypr/syfon)](https://github.com/calypr/syfon/releases)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../CONTRIBUTING.md)
+[![GitHub Stars](https://img.shields.io/github/stars/calypr/syfon?style=social)](https://github.com/calypr/syfon/stargazers)
+
 This module provides a reusable Go client for Syfon APIs.
 
 - Module: `github.com/calypr/syfon/client`

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -94,7 +94,7 @@ func TestDataUploadBlank(t *testing.T) {
 
 func TestIndexListByHash(t *testing.T) {
 	t.Parallel()
-	rec := InternalRecord{}
+	rec := InternalRecordRequest{}
 	(&rec).SetDid("id-1")
 	c := newTestClient(t, func(r *http.Request) (*http.Response, error) {
 		if r.Method != http.MethodGet || r.URL.Path != "/index" {
@@ -103,7 +103,7 @@ func TestIndexListByHash(t *testing.T) {
 		if got := r.URL.Query().Get("hash"); got != "sha256:deadbeef" {
 			t.Fatalf("unexpected hash query: %q", got)
 		}
-		data, _ := json.Marshal(ListRecordsResponse{Records: []InternalRecord{rec}})
+		data, _ := json.Marshal(ListRecordsResponse{Records: []InternalRecordRequest{rec}})
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(string(data))),

--- a/client/drs/client_bulk_endpoints_test.go
+++ b/client/drs/client_bulk_endpoints_test.go
@@ -95,7 +95,7 @@ func TestBatchGetObjectsByHash_UsesBulkHashesEndpoint(t *testing.T) {
 		size := int64(12)
 		resp := internalapi.ListRecordsResponse{
 			Records: []internalapi.InternalRecord{{
-				Did:      &did,
+				Did:      did,
 				FileName: &fileName,
 				Hashes:   &hashes,
 				Size:     &size,
@@ -158,7 +158,7 @@ func TestRegisterRecords_UsesBulkCreateEndpoint(t *testing.T) {
 		size := int64(21)
 		resp := internalapi.ListRecordsResponse{
 			Records: []internalapi.InternalRecord{{
-				Did:      &did,
+				Did:      did,
 				FileName: &fileName,
 				Hashes:   &hashes,
 				Size:     &size,

--- a/client/go.mod
+++ b/client/go.mod
@@ -99,3 +99,5 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 )
+
+replace github.com/calypr/syfon/apigen => ../apigen

--- a/client/xfer/download/transfer.go
+++ b/client/xfer/download/transfer.go
@@ -193,6 +193,7 @@ func downloadToPathSingle(
 	fdr := downloadRequest{guid: guid}
 	if existingSize > 0 {
 		fdr.rangeBytes = existingSize
+		fdr.rangeStart = &fdr.rangeBytes
 	}
 
 	if err := GetDownloadResponse(ctx, bk, &fdr, protocol); err != nil {

--- a/client/xfer/upload/multipart_test.go
+++ b/client/xfer/upload/multipart_test.go
@@ -77,10 +77,34 @@ func (f *fakeGen3Upload) CompleteMultipartUpload(ctx context.Context, key string
 	return err
 }
 func (f *fakeGen3Upload) Upload(ctx context.Context, url string, body io.Reader, size int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, body)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("upload failed: %s", resp.Status)
+	}
 	return nil
 }
 func (f *fakeGen3Upload) UploadPart(ctx context.Context, url string, body io.Reader, size int64) (string, error) {
-	return "", nil
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, body)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("upload part failed: %s", resp.Status)
+	}
+	return resp.Header.Get("ETag"), nil
 }
 func (f *fakeGen3Upload) DeleteFile(ctx context.Context, guid string) (string, error) {
 	return "", nil

--- a/client/xfer/upload/multipart_test.go
+++ b/client/xfer/upload/multipart_test.go
@@ -85,6 +85,9 @@ func (f *fakeGen3Upload) UploadPart(ctx context.Context, url string, body io.Rea
 func (f *fakeGen3Upload) DeleteFile(ctx context.Context, guid string) (string, error) {
 	return "", nil
 }
+func (f *fakeGen3Upload) CanonicalObjectURL(signedURL, bucketHint, fallbackDID string) (string, error) {
+	return signedURL, nil
+}
 
 func TestMultipartUploadProgressIntegration(t *testing.T) {
 	ctx := context.Background()

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+      root:
+        flags:
+          - root
+        target: auto
+        threshold: 1%
+      client:
+        flags:
+          - client
+        target: auto
+        threshold: 1%
+
+flags:
+  root:
+    carryforward: true
+  client:
+    carryforward: true
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,13 @@
 codecov:
   require_ci_to_pass: true
 
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
 coverage:
   precision: 2
   round: down
@@ -26,4 +33,3 @@ flags:
     carryforward: true
   client:
     carryforward: true
-


### PR DESCRIPTION
## Title
Add MIT license, README badges, and Codecov coverage reporting for root + client modules

## What changed

### 1) Added MIT license
- Added `LICENSE` with standard MIT text.

### 2) Added badges to main README
- Updated `README.md` to include badges for:
  - Go Reference
  - Go Report Card
  - Go Version
  - CI workflow
  - Codecov coverage
  - Snyk security
  - MIT license
  - Latest release
  - PRs welcome
  - GitHub stars
- Added a `## License` section linking to `LICENSE`.

### 3) Synced badge block to client README
- Updated `client/README.md` with the same badge set.
- Adjusted relative links for subdirectory context:
  - `../LICENSE`
  - `../CONTRIBUTING.md`

### 4) Enabled Codecov in CI for root and client
- Updated `.github/workflows/ci.yaml`:
  - Added workflow permissions for OIDC:
    - `contents: read`
    - `id-token: write`
  - Added client coverage generation step:
    - `client/coverage/coverage.out`
  - Added Codecov upload step using `codecov/codecov-action@v5` with:
    - `use_oidc: true`
    - `files: coverage/coverage.out,client/coverage/coverage.out`
    - `flags: root,client`
    - `fail_ci_if_error: true`
  - Included client coverage profile in uploaded CI artifacts.
- Added `codecov.yml` to define:
  - project status checks
  - separate `root` and `client` flags
  - carryforward behavior for both flags

## Why

- Clarifies repository licensing for users and contributors.
- Improves repository discoverability and trust signals via standard badges.
- Adds monorepo-aware coverage reporting so both the root module and `client` module are visible in Codecov.
- Ensures coverage upload failures are surfaced directly in CI.

## Validation

- Verified workflow updates in `.github/workflows/ci.yaml`.
- Ran client coverage command locally to confirm profile generation:
  - `client/coverage/coverage.out` is produced.

## Notes / follow-up

- Codecov and Snyk badges may show unknown/empty until those services are fully configured for this repo/org.
- If needed, we can add stricter per-flag coverage targets in `codecov.yml` in a follow-up PR.
