### PR TITLE
Fixing issues in CLI interface found when testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,7 @@ auth:
 database:
   sqlite:
     file: "drs.db"
-database:
-  sqlite:
-    file: "drs.db"
+
 s3_credentials:
   - bucket: "test-bucket"
     region: "us-east-1"

--- a/cmd/get/main.go
+++ b/cmd/get/main.go
@@ -1,0 +1,42 @@
+package get
+
+import (
+	"encoding/json"
+	"fmt"
+
+	syclient "github.com/calypr/syfon/client"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get DRS record",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		serverURL, err := cmd.Flags().GetString("server")
+		if err != nil {
+			return fmt.Errorf("get server flag: %w", err)
+		}
+		c, err := syclient.New(serverURL)
+		if err != nil {
+			return err
+		}
+
+		for _, i := range args {
+			record, err := c.Index().Get(cmd.Context(), i)
+			if err == nil {
+				txt, err := json.Marshal(record)
+				if err == nil {
+					fmt.Printf("%s\n", txt)
+				}
+			} else {
+				fmt.Printf("Error getting record for %s: %v\n", i, err)
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/calypr/syfon/cmd/addurl"
 	"github.com/calypr/syfon/cmd/bucket"
 	"github.com/calypr/syfon/cmd/download"
+	"github.com/calypr/syfon/cmd/get"
 	listcmd "github.com/calypr/syfon/cmd/list"
 	"github.com/calypr/syfon/cmd/ping"
 	"github.com/calypr/syfon/cmd/rm"
@@ -48,6 +49,7 @@ func init() {
 	RootCmd.AddCommand(bucket.Cmd)
 	RootCmd.AddCommand(addurl.Cmd)
 	RootCmd.AddCommand(upload.Cmd)
+	RootCmd.AddCommand(get.Cmd)
 	RootCmd.AddCommand(download.Cmd)
 	RootCmd.AddCommand(sha256sum.Cmd)
 	RootCmd.AddCommand(listcmd.Cmd)

--- a/cmd/upload/main.go
+++ b/cmd/upload/main.go
@@ -30,6 +30,10 @@ var Cmd = &cobra.Command{
 		}
 
 		srcPath := strings.TrimSpace(uploadFile)
+		srcPath, err := filepath.Abs(srcPath)
+		if err != nil {
+			return fmt.Errorf("resolve absolute path: %w", err)
+		}
 		info, err := os.Stat(srcPath)
 		if err != nil {
 			return fmt.Errorf("stat source file: %w", err)
@@ -39,9 +43,9 @@ var Cmd = &cobra.Command{
 		}
 
 		authz := strings.TrimSpace(uploadAuthz)
-		if authz == "" {
-			return fmt.Errorf("--authz is required")
-		}
+		//note: if authz is empty, will assume the server will allow
+		//unauthenticated uploads. This is not recommended for production,
+		//but can be useful for testing.
 
 		serverURL, err := cmd.Flags().GetString("server")
 		if err != nil {


### PR DESCRIPTION
Fixing stutter in README, adding no-authz upload (for testing) and adding `get` command for looking at records.

```
$ ./syfon upload --file README.md
Uploading /Users/ellrott/workspaces/calypr/drs-server/README.md (9.5KB)...
DID: 1f82a90a53a4a804667dc923d75d2736e450817b10095f4bfadde0f1fcba960c

successfully uploaded 1f82a90a53a4a804667dc923d75d2736e450817b10095f4bfadde0f1fcba960c

$ ./syfon get 1f82a90a53a4a804667dc923d75d2736e450817b10095f4bfadde0f1fcba960c
{"authz":[""],"created_date":"2026-04-14T20:57:22-07:00","created_time":"2026-04-14T20:57:22-07:00","description":"","did":"1f82a90a53a4a804667dc923d75d2736e450817b10095f4bfadde0f1fcba960c","file_name":"","hashes":{"sha256":"1f82a90a53a4a804667dc923d75d2736e450817b10095f4bfadde0f1fcba960c"},"size":9716,"updated_date":"2026-04-14T20:57:22-07:00","updated_time":"2026-04-14T20:57:22-07:00","urls":["s3://labdata/1f82a90a53a4a804667dc923d75d2736e450817b10095f4bfadde0f1fcba960c"],"version":""}

```
