### PR TITLE
feat: Update CI coverage to include binary/executable operations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,15 @@ jobs:
             -run 'Test(AllRegisteredEndpoints_WithMocks|RegisterAPIRoutes_StaticBeforeParamAcrossControllers|RegisterControllerRoutes_StaticBeforeParam)' \
             -v
 
+      - name: Run instrumented binary endpoint tests
+        run: |
+          mkdir -p coverage/gocover-endpoint
+          export GOCOVERDIR="$(pwd)/coverage/gocover-endpoint"
+          CGO_ENABLED=1 go test ./tests/endpoints/... \
+            -run 'Test(AllRegisteredEndpoints_WithMocks|RegisterAPIRoutes_StaticBeforeParamAcrossControllers|RegisterControllerRoutes_StaticBeforeParam)' \
+            -v
+          go tool covdata textfmt -i "$GOCOVERDIR" -o coverage/binary-endpoint.out
+
       - name: Run coverage
         env:
           SYFON_E2E_MOCK_SERVERS: 1
@@ -55,6 +64,34 @@ jobs:
         run: |
           mkdir -p coverage
           go test -count=1 -covermode=atomic -coverprofile=coverage/coverage.out ./...
+
+      - name: Upload binary endpoint coverage to Codecov (OIDC)
+        id: codecov_binary_endpoint_oidc
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_SLUG: calypr/syfon
+        with:
+          use_oidc: true
+          files: coverage/binary-endpoint.out
+          flags: binary-endpoint
+          disable_search: true
+          verbose: true
+          fail_ci_if_error: true
+
+      - name: Upload binary endpoint coverage to Codecov (token fallback)
+        if: steps.codecov_binary_endpoint_oidc.outcome == 'failure'
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_SLUG: calypr/syfon
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/binary-endpoint.out
+          flags: binary-endpoint
+          disable_search: true
+          verbose: true
+          fail_ci_if_error: false
 
       - name: Upload root coverage to Codecov (OIDC)
         id: codecov_root_oidc
@@ -119,6 +156,7 @@ jobs:
             coverage/coverage.out
             coverage/coverage.txt
             coverage/coverage.html
+            coverage/binary-endpoint.out
             client/coverage/coverage.out
 
       - name: Run go vet

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://pkg.go.dev/github.com/calypr/syfon"><img src="https://pkg.go.dev/badge/github.com/calypr/syfon.svg" alt="Go Reference"></a>
   <a href="https://goreportcard.com/report/github.com/calypr/syfon"><img src="https://goreportcard.com/badge/github.com/calypr/syfon" alt="Go Report Card"></a>
   <a href="https://github.com/calypr/syfon/actions/workflows/ci.yaml"><img src="https://github.com/calypr/syfon/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
-  <a href="https://codecov.io/gh/calypr/syfon"><img src="https://codecov.io/gh/calypr/syfon/branch/main/graph/badge.svg" alt="Coverage"></a>
+  <a href="https://app.codecov.io/gh/calypr/syfon/tree/development"><img src="https://codecov.io/gh/calypr/syfon/branch/development/graph/badge.svg" alt="Coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a href="https://github.com/calypr/syfon/releases"><img src="https://img.shields.io/github/v/release/calypr/syfon" alt="Latest Release"></a>

--- a/tests/endpoints/main_test.go
+++ b/tests/endpoints/main_test.go
@@ -52,7 +52,12 @@ func runTests(m *testing.M) int {
 	}
 	defer os.Remove(binaryPath)
 
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
+	buildArgs := []string{"build", "-o", binaryPath}
+	if gocoverdir := os.Getenv("GOCOVERDIR"); gocoverdir != "" {
+		buildArgs = append(buildArgs, "-cover", "-covermode=atomic", "-coverpkg=./...")
+	}
+	buildArgs = append(buildArgs, ".")
+	buildCmd := exec.Command("go", buildArgs...)
 	buildCmd.Dir = rootDir
 	if out, err := buildCmd.CombinedOutput(); err != nil {
 		panic(fmt.Sprintf("failed to build binary: %v\n%s", err, string(out)))
@@ -60,12 +65,17 @@ func runTests(m *testing.M) int {
 
 	cmd := exec.Command(binaryPath, "serve")
 	cmd.Dir = rootDir
-	cmd.Env = append(
+	serverEnv := append(
 		os.Environ(),
 		"DRS_PORT=9005",
 		"DRS_DB_SQLITE_FILE=drs_test.db",
 		"DRS_AUTH_MODE=local",
 	)
+	// Coverage-instrumented binaries write their data to GOCOVERDIR on exit.
+	if gocoverdir := os.Getenv("GOCOVERDIR"); gocoverdir != "" {
+		serverEnv = append(serverEnv, "GOCOVERDIR="+gocoverdir)
+	}
+	cmd.Env = serverEnv
 
 	// Put the child in its own process group so we can kill the whole tree.
 	cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
# Overview 🌀

This PR resolves #60 by including the built CLI executable in test coverage!

## Current Behavior ⚠️

CI Coverage is missed for common user operations involving the built Syfon executable.

## New Behavior ✔️

CI Coverage now includes Syfon executable tests. 

### Acceptance criteria

- [x] A CI job builds the root binary with `-cover -coverpkg=./...`.
- [x] Binary-driven tests run with `GOCOVERDIR` set.
- [x] Coverage from `go tool covdata textfmt` is uploaded to Codecov.
- [x] Codecov/package metrics show increased coverage for command/root execution paths touched by binary-driven tests.