### PR TITLE
fix: Multipart upload (PR #57)

### DIFF
--- a/internal/api/internaldrs/data_test.go
+++ b/internal/api/internaldrs/data_test.go
@@ -345,8 +345,8 @@ func TestHandleInternalMultipartInit(t *testing.T) {
 	om := core.NewObjectManager(mockDB, mockUM)
 	handleInternalMultipartInit(rr, req, om)
 
-	if status := rr.Code; status != http.StatusCreated {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
 	bodyBytes := rr.Body.Bytes()
@@ -390,8 +390,8 @@ func TestHandleInternalMultipartInit_MintsUUIDForChecksumInput(t *testing.T) {
 	om := core.NewObjectManager(mockDB, mockUM)
 	handleInternalMultipartInit(rr, req, om)
 
-	if status := rr.Code; status != http.StatusCreated {
-		t.Fatalf("handler returned wrong status code: got %v want %v body=%s", status, http.StatusCreated, rr.Body.String())
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v body=%s", status, http.StatusOK, rr.Body.String())
 	}
 
 	var resp internalapi.InternalMultipartInitOutput
@@ -445,8 +445,8 @@ func TestHandleInternalMultipartInit_ResolvesExistingByChecksumGUID(t *testing.T
 	om := core.NewObjectManager(mockDB, mockUM)
 	handleInternalMultipartInit(rr, req, om)
 
-	if status := rr.Code; status != http.StatusCreated {
-		t.Fatalf("handler returned wrong status code: got %v want %v body=%s", status, http.StatusCreated, rr.Body.String())
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v body=%s", status, http.StatusOK, rr.Body.String())
 	}
 
 	var resp internalapi.InternalMultipartInitOutput

--- a/internal/api/internaldrs/upload.go
+++ b/internal/api/internaldrs/upload.go
@@ -252,7 +252,7 @@ func handleInternalMultipartInitFiber(om *core.ObjectManager) fiber.Handler {
 		}
 
 		multipartUploadSessions.Store(uploadID, multipartSession{Bucket: bucket, Key: internalID})
-		return c.Status(fiber.StatusCreated).JSON(internalapi.InternalMultipartInitOutput{
+		return c.Status(fiber.StatusOK).JSON(internalapi.InternalMultipartInitOutput{
 			UploadId: &uploadID,
 			Guid:     &internalID,
 		})


### PR DESCRIPTION
# Overview

This PR updates Syfon's multipart status code to allow large files (>5GB) to be uploaded!

> [!NOTE]
>
> Tested against PR #57 (Commit [6e1cb71](https://github.com/calypr/syfon/pull/57/commits/6e1cb71e333fbd77e6f87474e63a5a7a3bfa2fef) / [Review Comment](https://github.com/calypr/syfon/pull/57#issuecomment-4271837764))

## Current Behavior ❌

```sh
➜ syfon upload --file test-file-10gb --authz example-scope

ERROR command execution failed err="upload failed: multipart upload failed: failed to init multipart: 201"
```

## New Behavior ✅

```sh
➜ syfon upload --file test-file-10gb --authz example-scope
Uploading test-file-10gb (10.0GB)...
DID: <DID>

successfully uploaded <DID>

➜ mc ls local/local-bucket
10GiB c0c5c25f-44f3-5c22-b3a2-98e7a1003159
```