### PR TITLE
fix make serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ coverage-full:
 
 .PHONY: serve
 serve:
-	go run ./cmd/server $(ARGS)
+	go run . serve $(ARGS)
 
 .PHONY: docs
 docs:

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The project uses a Makefile for common tasks:
 - `make test-unit`: Runs unit tests only (excludes integration packages).
 - `make coverage`: Runs coverage for core production packages (db/service/middleware/url signing) and writes `coverage/coverage.out`, `coverage/coverage.txt`, and `coverage/coverage.html`.
 - `make coverage-full`: Runs broader compatibility-layer coverage (includes internal compatibility and LFS packages).
-- `make serve`: Starts the DRS server.
+- `make serve ARGS="--config /path/to/config.yaml"`: Starts the DRS server.
 
 ## OpenAPI Codegen
 


### PR DESCRIPTION
# Fix `make serve` target

## Problem
Running `make serve` was failing with the error:
```
package github.com/calypr/syfon/cmd/server is not a main package
```

This occurred because the `serve` Make target was attempting to run `./cmd/server` as a standalone Go package, but `cmd/server` is a library package containing a Cobra subcommand, not a `main` package.

## Solution
Updated the `serve` Make target to invoke the root main package and execute the `serve` subcommand through Cobra:

**Before:**
```makefile
serve:
	go run ./cmd/server $(ARGS)
```

**After:**
```makefile
serve:
	go run . serve $(ARGS)
```

## Changes
- Modified `Makefile` line 182 to use the correct entry point
- The root `main.go` is the actual executable entry point (package `main`)
- The `serve` command is registered as a Cobra subcommand in `cmd.RootCmd`
- The `ARGS` variable is preserved for passing configuration and other flags

## Testing
Verified that:
- `make serve` now executes without the "not a main package" error
- The server command is properly exposed through the Cobra CLI
- Configuration flags can be passed: `make serve ARGS="--config ./config.yaml"`
- The command fails gracefully with appropriate error messages when config is missing

## Usage
```bash
# Start server with default config
make serve

# Start server with custom config
make serve ARGS="--config /path/to/config.yaml"
```

