### PR TITLE
change issuers to be derived from fence keyset endpoint user/jwt/keys

### DIFF
--- a/internal/api/middleware/authz.go
+++ b/internal/api/middleware/authz.go
@@ -34,6 +34,13 @@ type AuthzMiddleware struct {
 	mock      mockAuthConfig
 	cache     *authzCache
 	sf        singleflight.Group
+
+	// jwksCachesMu guards jwksCaches.
+	jwksCachesMu sync.Mutex
+	// jwksCaches holds one JWKSCache per issuer origin, keyed by the
+	// normalized origin (scheme://host). Lazily populated on first token
+	// for that issuer and reused across requests.
+	jwksCaches map[string]*JWKSCache
 }
 
 type mockAuthConfig struct {
@@ -72,12 +79,13 @@ func NewAuthzMiddleware(logger *slog.Logger, mode, basicUser, basicPass string) 
 		cache = newAuthzCache(cfg)
 	}
 	return &AuthzMiddleware{
-		logger:    logger,
-		mode:      strings.ToLower(strings.TrimSpace(mode)),
-		basicUser: basicUser,
-		basicPass: basicPass,
-		mock:      loadMockAuthConfigFromEnv(),
-		cache:     cache,
+		logger:     logger,
+		mode:       strings.ToLower(strings.TrimSpace(mode)),
+		basicUser:  basicUser,
+		basicPass:  basicPass,
+		mock:       loadMockAuthConfigFromEnv(),
+		cache:      cache,
+		jwksCaches: make(map[string]*JWKSCache),
 	}
 }
 
@@ -473,26 +481,19 @@ func splitCSV(raw string) []string {
 }
 
 func (m *AuthzMiddleware) parseToken(tokenString string) (endpoint string, exp float64, err error) {
-	// SECURITY FIX CRIT-1: Verify JWT signature cryptographically
-	// This is the PRIMARY defense against token forgery attacks
-
-	// 1. Parse the JWT header to get KID and ISS claim
 	parser := jwt.NewParser(jwt.WithValidMethods([]string{"RS256", "RS384", "RS512"}))
 	var claims jwt.MapClaims
 
 	token, err := parser.ParseWithClaims(tokenString, &claims, func(token *jwt.Token) (interface{}, error) {
-		// CRITICAL: Verify the signing method is RSA (not "none" or symmetric)
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v (expected RSA)", token.Header["alg"])
 		}
 
-		// Extract KID from header
 		kid, ok := token.Header["kid"].(string)
 		if !ok || kid == "" {
 			return nil, fmt.Errorf("missing KID in token header")
 		}
 
-		// Extract ISS claim to determine which JWKS endpoint to use
 		iss, ok := claims["iss"].(string)
 		if !ok || iss == "" {
 			return nil, fmt.Errorf("missing or invalid 'iss' claim in token")
@@ -502,26 +503,18 @@ func (m *AuthzMiddleware) parseToken(tokenString string) (endpoint string, exp f
 		if err != nil {
 			return nil, fmt.Errorf("invalid issuer URL: %w", err)
 		}
-
-		// SECURITY FIX: Validate issuer against allowlist BEFORE fetching keys.
-		// Matching is done on normalized origin (scheme://host), not raw iss text.
-		if !isIssuerAllowed(origin) {
-			return nil, fmt.Errorf("issuer %q not in allowed list", iss)
+		if !strings.HasPrefix(origin, "https://") {
+			return nil, fmt.Errorf("issuer must use HTTPS, got: %s", origin)
 		}
 
-		// SECURITY FIX: Enforce HTTPS-only for JWKS fetching
-		jwksURL := origin + "/.well-known/jwks.json"
-		if !strings.HasPrefix(jwksURL, "https://") {
-			return nil, fmt.Errorf("JWKS endpoint must use HTTPS, got: %s", jwksURL)
-		}
+		// Fence-specific JWT keys endpoint. The path is fixed for all Gen3 deployments.
+		jwksURL := origin + "/user/jwt/keys"
 
-		// Fetch and cache JWKS keys
-		cache := NewJWKSCache(jwksURL, 15*time.Minute)
+		cache := m.getOrCreateJWKSCache(origin, jwksURL)
 		if err := cache.FetchKeys(); err != nil {
 			return nil, fmt.Errorf("fetch JWKS: %w", err)
 		}
 
-		// Get the public key for this KID
 		publicKey, err := cache.GetKey(kid)
 		if err != nil {
 			return nil, fmt.Errorf("key not found in JWKS (kid=%s): %w", kid, err)
@@ -534,12 +527,10 @@ func (m *AuthzMiddleware) parseToken(tokenString string) (endpoint string, exp f
 		return "", 0, fmt.Errorf("JWT signature verification failed: %w", err)
 	}
 
-	// Verify the token is valid
 	if !token.Valid {
 		return "", 0, fmt.Errorf("invalid token")
 	}
 
-	// Extract claims after successful verification
 	iss, ok := claims["iss"].(string)
 	if !ok || iss == "" {
 		return "", 0, fmt.Errorf("missing 'iss' claim")
@@ -549,40 +540,24 @@ func (m *AuthzMiddleware) parseToken(tokenString string) (endpoint string, exp f
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to normalize issuer URL: %w", err)
 	}
-	if !strings.HasPrefix(origin, "https://") {
-		return "", 0, fmt.Errorf("issuer URL must use https scheme, got %q", iss)
-	}
 
 	endpoint = origin
-
 	exp, _ = claims["exp"].(float64)
 
 	return endpoint, exp, nil
 }
 
-// isIssuerAllowed checks if an issuer URL is in the allowed list.
-// The allowlist is configured via DRS_ALLOWED_ISSUERS (comma-separated URLs).
-func isIssuerAllowed(iss string) bool {
-	issuerOrigin, err := normalizeIssuerOrigin(iss)
-	if err != nil {
-		return false
+// getOrCreateJWKSCache returns the cached JWKSCache for the given issuer origin,
+// creating one if it does not yet exist.
+func (m *AuthzMiddleware) getOrCreateJWKSCache(origin, jwksURL string) *JWKSCache {
+	m.jwksCachesMu.Lock()
+	defer m.jwksCachesMu.Unlock()
+	if c, ok := m.jwksCaches[origin]; ok {
+		return c
 	}
-
-	allowlist := splitCSV(os.Getenv("DRS_ALLOWED_ISSUERS"))
-	if len(allowlist) == 0 {
-		// If no allowlist is configured, reject all issuers
-		return false
-	}
-	for _, allowed := range allowlist {
-		allowedOrigin, err := normalizeIssuerOrigin(allowed)
-		if err != nil {
-			continue
-		}
-		if issuerOrigin == allowedOrigin {
-			return true
-		}
-	}
-	return false
+	c := NewJWKSCache(jwksURL, 15*time.Minute)
+	m.jwksCaches[origin] = c
+	return c
 }
 
 func normalizeIssuerOrigin(raw string) (string, error) {

--- a/internal/api/middleware/authz_jwt_signature_test.go
+++ b/internal/api/middleware/authz_jwt_signature_test.go
@@ -14,9 +14,6 @@ import (
 // TestJWTSignatureVerification tests that parseToken properly verifies JWT signatures
 func TestJWTSignatureVerification_ValidSignature(t *testing.T) {
 	// Setup allowed issuer
-	os.Setenv("DRS_ALLOWED_ISSUERS", "https://fence.example.com")
-	defer os.Unsetenv("DRS_ALLOWED_ISSUERS")
-
 	// Generate RSA key pair for signing
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -158,92 +155,11 @@ func TestJWTSignatureVerification_ExpiredToken(t *testing.T) {
 	t.Logf("✓ Expired token correctly rejected: %v", err)
 }
 
-// TestJWTSignatureVerification_IssuerAllowlist tests issuer validation
-func TestJWTSignatureVerification_IssuerAllowlist(t *testing.T) {
-	tests := []struct {
-		name           string
-		allowedIssuers string
-		tokenIss       string
-		shouldPass     bool
-	}{
-		{
-			name:           "allowed issuer",
-			allowedIssuers: "https://fence.example.com",
-			tokenIss:       "https://fence.example.com",
-			shouldPass:     true,
-		},
-		{
-			name:           "disallowed issuer",
-			allowedIssuers: "https://fence.example.com",
-			tokenIss:       "https://attacker.example.com",
-			shouldPass:     false,
-		},
-		{
-			name:           "multiple allowed, first matches",
-			allowedIssuers: "https://fence1.example.com,https://fence2.example.com",
-			tokenIss:       "https://fence1.example.com",
-			shouldPass:     true,
-		},
-		{
-			name:           "http scheme rejected",
-			allowedIssuers: "https://fence.example.com",
-			tokenIss:       "http://fence.example.com",
-			shouldPass:     false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("DRS_ALLOWED_ISSUERS", tt.allowedIssuers)
-			defer os.Unsetenv("DRS_ALLOWED_ISSUERS")
-
-			key, _ := rsa.GenerateKey(rand.Reader, 2048)
-
-			claims := jwt.MapClaims{
-				"iss": tt.tokenIss,
-				"exp": time.Now().Add(1 * time.Hour).Unix(),
-			}
-
-			token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-			tokenString, _ := token.SignedString(key)
-
-			// Try to parse
-			parser := jwt.NewParser()
-			_, err := parser.ParseWithClaims(tokenString, &jwt.MapClaims{}, func(t *jwt.Token) (interface{}, error) {
-				claimsPtr, ok := t.Claims.(*jwt.MapClaims)
-				if !ok || claimsPtr == nil {
-					return nil, fmt.Errorf("unexpected claims type: %T", t.Claims)
-				}
-
-				issAny, ok := (*claimsPtr)["iss"]
-				if !ok {
-					return nil, fmt.Errorf("missing iss claim")
-				}
-				issuer, ok := issAny.(string)
-				if !ok {
-					return nil, fmt.Errorf("iss claim is not a string")
-				}
-
-				if !isIssuerAllowed(issuer) {
-					return nil, fmt.Errorf("issuer not allowed")
-				}
-				return &key.PublicKey, nil
-			})
-			if tt.shouldPass && err != nil {
-				t.Errorf("Expected to pass but got error: %v", err)
-			}
-			if !tt.shouldPass && err == nil {
-				t.Errorf("Expected to fail but parsing succeeded")
-			}
-		})
-	}
-}
-
 // TestJWKSCache tests JWKS caching and key retrieval
 func TestJWKSCache_KeyRetrieval(t *testing.T) {
-	cache := NewJWKSCache("https://fence.example.com/.well-known/jwks.json", 15*time.Minute)
+	cache := NewJWKSCache("https://fence.example.com/user/jwt/keys", 15*time.Minute)
 
-	if cache.jwksURL != "https://fence.example.com/.well-known/jwks.json" {
+	if cache.jwksURL != "https://fence.example.com/user/jwt/keys" {
 		t.Errorf("JWKS URL not set correctly")
 	}
 
@@ -277,8 +193,8 @@ func TestSecurityFix_CRIT1_CompleteCoverage(t *testing.T) {
 	t.Log("✓ 2. KID extraction and validation")
 	t.Log("✓ 3. Algorithm whitelist (RS256, RS384, RS512 only)")
 	t.Log("✓ 4. Rejection of 'none' algorithm")
-	t.Log("✓ 5. Issuer allowlist validation")
-	t.Log("✓ 6. HTTPS-only enforcement for JWKS endpoints")
+	t.Log("✓ 5. HTTPS-only issuer enforcement")
+	t.Log("✓ 6. Public key fetch from Fence /user/jwt/keys endpoint")
 	t.Log("✓ 7. Public key caching via JWKS")
 	t.Log("✓ 8. Token expiration validation")
 
@@ -292,6 +208,6 @@ func TestSecurityFix_CRIT1_CompleteCoverage(t *testing.T) {
 	t.Log("  ├─ Cryptographic signature verification")
 	t.Log("  ├─ Public key validation via JWKS")
 	t.Log("  ├─ Algorithm enforcement")
-	t.Log("  ├─ Issuer allowlist check")
+	t.Log("  ├─ HTTPS-only issuer enforcement")
 	t.Log("  └─ Expiration validation")
 }

--- a/internal/api/middleware/authz_security_test.go
+++ b/internal/api/middleware/authz_security_test.go
@@ -6,10 +6,10 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -41,7 +41,7 @@ func TestParseToken_IssuerAllowlistValidation(t *testing.T) {
 	}
 
 	httpsJWKS := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/.well-known/jwks.json" {
+		if r.URL.Path != "/user/jwt/keys" {
 			http.NotFound(w, r)
 			return
 		}
@@ -50,7 +50,7 @@ func TestParseToken_IssuerAllowlistValidation(t *testing.T) {
 	defer httpsJWKS.Close()
 
 	httpJWKS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/.well-known/jwks.json" {
+		if r.URL.Path != "/user/jwt/keys" {
 			http.NotFound(w, r)
 			return
 		}
@@ -72,61 +72,31 @@ func TestParseToken_IssuerAllowlistValidation(t *testing.T) {
 	httpOrigin := httpJWKS.URL
 
 	tests := []struct {
-		name           string
-		allowedIssuers string
-		issuerClaim    string
-		expUnix        int64
-		wantErr        bool
-		errContains    string
-		wantEndpoint   string
+		name         string
+		issuerClaim  string
+		expUnix      int64
+		wantErr      bool
+		errContains  string
+		wantEndpoint string
 	}{
 		{
-			name:           "valid issuer with path in token matches allowlist origin",
-			allowedIssuers: httpsOrigin,
-			issuerClaim:    httpsOrigin + "/user",
-			expUnix:        1893456000,
-			wantEndpoint:   httpsOrigin,
+			name:         "valid https issuer with path — endpoint is normalized origin",
+			issuerClaim:  httpsOrigin + "/user",
+			expUnix:      1893456000,
+			wantEndpoint: httpsOrigin,
 		},
 		{
-			name:           "issuer not in allowlist",
-			allowedIssuers: httpsOrigin,
-			issuerClaim:    "https://attacker.example.com/user",
-			expUnix:        1893456000,
-			wantErr:        true,
-			errContains:    "not in allowed list",
-		},
-		{
-			name:           "http scheme rejected by jwks https enforcement",
-			allowedIssuers: httpOrigin,
-			issuerClaim:    httpOrigin + "/user",
-			expUnix:        1893456000,
-			wantErr:        true,
-			errContains:    "must use HTTPS",
-		},
-		{
-			name:           "empty allowlist rejects all",
-			allowedIssuers: "",
-			issuerClaim:    httpsOrigin,
-			expUnix:        1893456000,
-			wantErr:        true,
-			errContains:    "not in allowed list",
+			name:        "http issuer rejected — must use HTTPS",
+			issuerClaim: httpOrigin + "/user",
+			expUnix:     1893456000,
+			wantErr:     true,
+			errContains: "must use HTTPS",
 		},
 	}
 
-	m := &AuthzMiddleware{}
+	m := NewAuthzMiddleware(slog.Default(), "gen3", "", "")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldEnv := os.Getenv("DRS_ALLOWED_ISSUERS")
-			defer func() {
-				if oldEnv == "" {
-					_ = os.Unsetenv("DRS_ALLOWED_ISSUERS")
-					return
-				}
-				_ = os.Setenv("DRS_ALLOWED_ISSUERS", oldEnv)
-			}()
-
-			_ = os.Setenv("DRS_ALLOWED_ISSUERS", tt.allowedIssuers)
-
 			tokenString := buildTokenWithClaims(jwt.MapClaims{
 				"iss": tt.issuerClaim,
 				"exp": tt.expUnix,
@@ -156,16 +126,6 @@ func TestParseToken_IssuerAllowlistValidation(t *testing.T) {
 	}
 
 	t.Run("malformed iss claim rejects token", func(t *testing.T) {
-		oldEnv := os.Getenv("DRS_ALLOWED_ISSUERS")
-		defer func() {
-			if oldEnv == "" {
-				_ = os.Unsetenv("DRS_ALLOWED_ISSUERS")
-				return
-			}
-			_ = os.Setenv("DRS_ALLOWED_ISSUERS", oldEnv)
-		}()
-		_ = os.Setenv("DRS_ALLOWED_ISSUERS", httpsOrigin)
-
 		tokenString := buildTokenWithClaims(jwt.MapClaims{
 			"iss": 12345,
 			"exp": int64(1893456000),
@@ -187,108 +147,37 @@ func TestParseToken_IssuerAllowlistValidation(t *testing.T) {
 	})
 }
 
-func TestIsIssuerAllowed(t *testing.T) {
+func TestNormalizeIssuerOrigin(t *testing.T) {
 	tests := []struct {
-		name           string
-		allowedIssuers string
-		testIssuer     string
-		want           bool
+		name    string
+		input   string
+		want    string
+		wantErr bool
 	}{
-		{
-			name:           "exact match",
-			allowedIssuers: "https://fence.example.com",
-			testIssuer:     "https://fence.example.com",
-			want:           true,
-		},
-		{
-			name:           "no match",
-			allowedIssuers: "https://fence.example.com",
-			testIssuer:     "https://other.example.com",
-			want:           false,
-		},
-		{
-			name:           "multiple issuers - first matches",
-			allowedIssuers: "https://fence1.example.com,https://fence2.example.com",
-			testIssuer:     "https://fence1.example.com",
-			want:           true,
-		},
-		{
-			name:           "multiple issuers - second matches",
-			allowedIssuers: "https://fence1.example.com,https://fence2.example.com",
-			testIssuer:     "https://fence2.example.com",
-			want:           true,
-		},
-		{
-			name:           "empty allowlist",
-			allowedIssuers: "",
-			testIssuer:     "https://fence.example.com",
-			want:           false,
-		},
-		{
-			name:           "whitespace handling",
-			allowedIssuers: "https://fence1.example.com , https://fence2.example.com ",
-			testIssuer:     "https://fence2.example.com",
-			want:           true,
-		},
-		{
-			name:           "issuer path matches allowlist origin",
-			allowedIssuers: "https://fence.example.com",
-			testIssuer:     "https://fence.example.com/user",
-			want:           true,
-		},
-		{
-			name:           "allowlist path matches issuer origin",
-			allowedIssuers: "https://fence.example.com/user",
-			testIssuer:     "https://fence.example.com",
-			want:           true,
-		},
-		{
-			name:           "trailing slash ignored for origin match",
-			allowedIssuers: "https://fence.example.com/",
-			testIssuer:     "https://fence.example.com",
-			want:           true,
-		},
-		{
-			name:           "query and fragment ignored for origin match",
-			allowedIssuers: "https://fence.example.com",
-			testIssuer:     "https://fence.example.com/user?x=1#frag",
-			want:           true,
-		},
-		{
-			name:           "host case-insensitive match",
-			allowedIssuers: "https://FENCE.EXAMPLE.COM",
-			testIssuer:     "https://fence.example.com/user",
-			want:           true,
-		},
-		{
-			name:           "different host still rejected",
-			allowedIssuers: "https://fence.example.com",
-			testIssuer:     "https://evil.example.com/user",
-			want:           false,
-		},
-		{
-			name:           "invalid allowlist entries are ignored",
-			allowedIssuers: "not-a-url,https://fence.example.com/path",
-			testIssuer:     "https://fence.example.com",
-			want:           true,
-		},
+		{name: "bare origin", input: "https://fence.example.com", want: "https://fence.example.com"},
+		{name: "path stripped", input: "https://fence.example.com/user", want: "https://fence.example.com"},
+		{name: "path and query stripped", input: "https://fence.example.com/user?x=1#frag", want: "https://fence.example.com"},
+		{name: "trailing slash stripped", input: "https://fence.example.com/", want: "https://fence.example.com"},
+		{name: "host lowercased", input: "https://FENCE.EXAMPLE.COM", want: "https://fence.example.com"},
+		{name: "scheme lowercased", input: "HTTPS://fence.example.com", want: "https://fence.example.com"},
+		{name: "missing scheme errors", input: "fence.example.com", wantErr: true},
+		{name: "missing host errors", input: "https://", wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldEnv := os.Getenv("DRS_ALLOWED_ISSUERS")
-			defer func() {
-				if oldEnv != "" {
-					os.Setenv("DRS_ALLOWED_ISSUERS", oldEnv)
-				} else {
-					os.Unsetenv("DRS_ALLOWED_ISSUERS")
+			got, err := normalizeIssuerOrigin(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
 				}
-			}()
-
-			os.Setenv("DRS_ALLOWED_ISSUERS", tt.allowedIssuers)
-			got := isIssuerAllowed(tt.testIssuer)
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if got != tt.want {
-				t.Errorf("isIssuerAllowed(%q) = %v, want %v", tt.testIssuer, got, tt.want)
+				t.Errorf("normalizeIssuerOrigin(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/api/middleware/authz_test.go
+++ b/internal/api/middleware/authz_test.go
@@ -115,7 +115,7 @@ func TestParseToken(t *testing.T) {
 	}
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/.well-known/jwks.json" {
+		if r.URL.Path != "/user/jwt/keys" {
 			http.NotFound(w, r)
 			return
 		}
@@ -130,7 +130,6 @@ func TestParseToken(t *testing.T) {
 	defer func() { http.DefaultTransport = oldTransport }()
 
 	issuerOrigin := server.URL
-	t.Setenv("DRS_ALLOWED_ISSUERS", issuerOrigin)
 
 	buildToken := func(claims jwt.MapClaims) string {
 		tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)


### PR DESCRIPTION
Use fence public key to verify tokens instead of having to manually provide an issuer URL to verify the authenticity of the token