### PR TITLE
fix/data_file

### DIFF
--- a/internal/api/lfs/actions.go
+++ b/internal/api/lfs/actions.go
@@ -70,7 +70,7 @@ func prepareUploadActions(ctx context.Context, om *core.ObjectManager, oid strin
 		return nil, reqSize, dbErrToBatchError(ctx, err)
 	}
 
-	if err := om.RequireObjectResources(ctx, "create", []string{"/programs/data_file"}); err != nil {
+	if err := om.RequireObjectResources(ctx, "create", []string{"/data_file"}); err != nil {
 		return nil, reqSize, dbErrToBatchError(ctx, err)
 	}
 

--- a/internal/api/lfs/actions_test.go
+++ b/internal/api/lfs/actions_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/calypr/syfon/apigen/server/drs"
+	internalauth "github.com/calypr/syfon/internal/auth"
+	"github.com/calypr/syfon/internal/core"
 	"github.com/calypr/syfon/internal/testutils"
 )
 
@@ -57,3 +59,60 @@ func TestResolveObjectForOIDFallsBackToChecksum(t *testing.T) {
 		t.Fatalf("expected object id %s, got %+v", did, obj)
 	}
 }
+
+func TestPrepareUploadActionsRequiresGlobalDataFileCreate(t *testing.T) {
+	testCases := []struct {
+		name       string
+		privileges map[string]map[string]bool
+		wantCode   int32
+	}{
+		{
+			name:       "allows global create privilege",
+			privileges: map[string]map[string]bool{"/data_file": {"create": true}},
+		},
+		{
+			name:       "rejects org-scoped alias privilege",
+			privileges: map[string]map[string]bool{"/programs/data_file": {"create": true}},
+			wantCode:   int32(http.StatusForbidden),
+		},
+		{
+			name:       "rejects read-only global privilege",
+			privileges: map[string]map[string]bool{"/data_file": {"read": true}},
+			wantCode:   int32(http.StatusForbidden),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := internalauth.NewSession("gen3")
+			session.AuthHeaderPresent = true
+			session.SetAuthorizations(nil, tc.privileges, true)
+			ctx := internalauth.WithSession(context.Background(), session)
+
+			db := &testutils.MockDatabase{Objects: map[string]*drs.DrsObject{}}
+			om := core.NewObjectManager(db, &testutils.MockUrlManager{})
+			actions, size, objErr := prepareUploadActions(ctx, om, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 123, "https://example.test")
+
+			if tc.wantCode != 0 {
+				if objErr == nil || objErr.Code != tc.wantCode {
+					t.Fatalf("expected object error code %d, got %+v", tc.wantCode, objErr)
+				}
+				if size != 123 {
+					t.Fatalf("expected unchanged requested size on denied upload, got %d", size)
+				}
+				return
+			}
+
+			if objErr != nil {
+				t.Fatalf("expected success, got object error: %+v", objErr)
+			}
+			if actions == nil || actions.Upload == nil || actions.Verify == nil {
+				t.Fatalf("expected upload and verify actions, got %+v", actions)
+			}
+			if size != 123 {
+				t.Fatalf("expected size 123, got %d", size)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## PR Title
Fix LFS upload authz gate to require global `/data_file` create permission

## Why
LFS upload authorization was checking `"/programs/data_file"` instead of the global `"/data_file"` resource used elsewhere in authz flow.  
Because normalization can treat `"/programs/data_file"` as org-scoped, valid callers with global `create` on `"/data_file"` were incorrectly denied.

## What changed
- Updated LFS upload permission-gate behavior to align with the global resource convention:
  - require `create` on `"/data_file"`
  - do not treat `"/programs/data_file"` alias as equivalent for this gate

## Tests
Added/updated tests in `internal/api/lfs/actions_test.go`:

- `TestPrepareUploadActionsRequiresGlobalDataFileCreate`
  - allows: `"/data_file": {"create": true}`
  - rejects: `"/programs/data_file": {"create": true}` (forbidden)
  - rejects: `"/data_file": {"read": true}` (forbidden)

Also retains nearby regression coverage in the same file:
- `TestUploadPartToSignedURLFaultInjection`
- `TestResolveObjectForOIDFallsBackToChecksum`

## Impact
- Prevents false `unauthorized/forbidden` responses for legitimate global file creators.
- Aligns LFS upload authz checks with existing global resource usage across the codebase.

## Reviewer checklist
- [ ] Confirm LFS create gate uses `"/data_file"` (global) semantics
- [ ] Confirm org-scoped alias does not bypass/replace required global permission
- [ ] Confirm no regressions in upload action preparation path